### PR TITLE
Added tracking for checked CertificateToken to avoid infinite loops 

### DIFF
--- a/dss-document/src/main/java/eu/europa/esig/dss/validation/DiagnosticDataBuilder.java
+++ b/dss-document/src/main/java/eu/europa/esig/dss/validation/DiagnosticDataBuilder.java
@@ -384,16 +384,16 @@ public class DiagnosticDataBuilder {
 
 	private List<XmlChainItem> getXmlForCertificateChain(CertificateToken token) {
 		if (token != null) {
-
 			CertificateToken issuerToken_ = token;
+			Set<CertificateToken> processedTokens = new HashSet<>();
 			final List<XmlChainItem> certChainTokens = new ArrayList<XmlChainItem>();
 			do {
-
 				certChainTokens.add(getXmlChainItem(issuerToken_));
-				if (issuerToken_.isTrusted() || issuerToken_.isSelfSigned()) {
+				if (issuerToken_.isTrusted() || issuerToken_.isSelfSigned() || processedTokens.contains(issuerToken_)) {
 
 					break;
 				}
+				processedTokens.add(issuerToken_);
 				issuerToken_ = issuerToken_.getIssuerToken();
 			} while (issuerToken_ != null);
 			return certChainTokens;

--- a/dss-document/src/main/java/eu/europa/esig/dss/validation/DiagnosticDataBuilder.java
+++ b/dss-document/src/main/java/eu/europa/esig/dss/validation/DiagnosticDataBuilder.java
@@ -385,7 +385,7 @@ public class DiagnosticDataBuilder {
 	private List<XmlChainItem> getXmlForCertificateChain(CertificateToken token) {
 		if (token != null) {
 			CertificateToken issuerToken_ = token;
-			Set<CertificateToken> processedTokens = new HashSet<>();
+			Set<CertificateToken> processedTokens = new HashSet<CertificateToken>();
 			final List<XmlChainItem> certChainTokens = new ArrayList<XmlChainItem>();
 			do {
 				certChainTokens.add(getXmlChainItem(issuerToken_));

--- a/dss-model/src/main/java/eu/europa/esig/dss/x509/CertificateToken.java
+++ b/dss-model/src/main/java/eu/europa/esig/dss/x509/CertificateToken.java
@@ -407,8 +407,10 @@ public class CertificateToken extends Token {
 		if (isSelfSigned() && isTrusted()) {
 			return this;
 		}
+		Set<CertificateToken> processedTokens = new HashSet<>();
 		CertificateToken issuerCertToken = getIssuerToken();
-		while (issuerCertToken != null) {
+		while ((issuerCertToken != null) && (!processedTokens.contains(issuerCertToken))) {
+			processedTokens.add(issuerCertToken);
 			if (issuerCertToken.isTrusted()) {
 				return issuerCertToken;
 			}

--- a/dss-model/src/main/java/eu/europa/esig/dss/x509/CertificateToken.java
+++ b/dss-model/src/main/java/eu/europa/esig/dss/x509/CertificateToken.java
@@ -407,7 +407,7 @@ public class CertificateToken extends Token {
 		if (isSelfSigned() && isTrusted()) {
 			return this;
 		}
-		Set<CertificateToken> processedTokens = new HashSet<>();
+		Set<CertificateToken> processedTokens = new HashSet<CertificateToken>();
 		CertificateToken issuerCertToken = getIssuerToken();
 		while ((issuerCertToken != null) && (!processedTokens.contains(issuerCertToken))) {
 			processedTokens.add(issuerCertToken);

--- a/dss-spi/src/main/java/eu/europa/esig/dss/DSSASN1Utils.java
+++ b/dss-spi/src/main/java/eu/europa/esig/dss/DSSASN1Utils.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -567,8 +568,10 @@ public final class DSSASN1Utils {
 
 	private static List<String> getServiceSupplyPoints(CertificateToken certificateToken, String... keywords) {
 		List<String> urls = new ArrayList<String>();
+		Set<CertificateToken> processedCertificates = new HashSet<CertificateToken>();
 		CertificateToken issuerToken = certificateToken.getIssuerToken();
-		while (issuerToken != null) {
+		while ((issuerToken != null) && (!processedCertificates.contains(issuerToken))) {
+			processedCertificates.add(issuerToken);
 			if (issuerToken.isTrusted() && Utils.isCollectionNotEmpty(issuerToken.getAssociatedTSPS())) {
 				Set<ServiceInfo> services = issuerToken.getAssociatedTSPS();
 				for (ServiceInfo serviceInfo : services) {


### PR DESCRIPTION
In many places checking certificate chain involves looping around the certificates returned from CertificateToken.getIssuerToken(). 
On US Government PIV PKI, there are cases of cross-references where certificate from entity A is issued by entity B and certificate from entity B is issued by entity A. Such situations cause infinite loops during validation process.
To prevent this problem, a set was created to track the CertificateToken objects already checked.